### PR TITLE
Detector data analysis

### DIFF
--- a/D4.1_2/WP4_D4.1_2.tex
+++ b/D4.1_2/WP4_D4.1_2.tex
@@ -11,9 +11,6 @@
 %\usepackage{nomencl}
 \usepackage{hyperref}
 
-\usepackage[nonumberlist]{glossaries}
-
-
 
 \renewcommand*\finalnamedelim{, and\addspace}
 \DeclareNameAlias{sortname}{last-first}
@@ -45,9 +42,6 @@
 \author{Carsten Fortmann-Grote, Axel Huebl, Michael Bussmann } % Add yourself.
 \date{\today}
 
-\makeglossaries
-\newacronym[longplural={Free Electron Lasers}]{fel}{FEL}{Free Electron Laser}
-
 \begin{document}
 \maketitle
 \abstract{%
@@ -69,7 +63,8 @@ concrete simulation tools for two virtual experiments:
 The computer program \texttt{simex\_platform}
 \cite{simex_github}
 is a platform for simulation of experiments at advanced laser light sources. The user can
-assemble a virtual experiment through combination of suitable programs for the light source (e.g. synchrotron, \gls{fel}, or conventional laser),
+assemble a virtual experiment through combination of suitable programs for the light source (e.g. synchrotron, free electron
+laser, or conventional laser),
 beam transport from source to sample or target, interaction of the light with the sample or target,
 propagation of the scattered light behind the interaction, and finally detection in a light detector.
 \texttt{simex\_platform} comes preloaded with
@@ -92,7 +87,7 @@ from the source to the experiment, the interaction of photons and matter, propag
 target/sample to the detector and detection in a detector, followed by data analysis. Later in this report, we will discuss two
 concrete examples for photon-based experiments. Both of them are so-called pump-probe experiments, i.e. they involve two photon
 sources, typically one optical source and one x-ray source. However, only the x-ray source will actually be simulated while the
-optical laser will be parametrized. More complex experiments, FELs based on compact
+optical laser will be parametrized. More complex experiments, e.g. FELs based on compact
 laser-plasma electron accelerators are currently beyond the scope of the toolchain described above. But with slight
 modifications to the framework, they can also be included in a somewhat more
 flexible scheme which allows reordering of the \textit{Calculators}.
@@ -111,7 +106,7 @@ level. The
 The mechanism to generate the radiation before any optical elements and before any photon-matter interaction has happened.
 \begin{description}
   \item[Abstract calculator:] AbstractPhotonSource
-  \item[Physics:] Depending on nature of the source: radiation from charged particle acceleration, spontanuous emission, laser medium.
+  \item[Physics:] Depending on nature of the source: radiation from charged particle acceleration, spontaneous emission, laser medium.
   \item[Input data:] Parameters of the photon source, e.g. for an undulator: electron bunch charge, electron energy, undulator period and length.
   \item[Output data:] Representation of the light source (e.g. as a wavefront, rays, photon distribution)
   \item[Example method:] The code FAST \cite{Saldin1999} generates 3D (x-y-t) wavefronts at the exit of the undulator in an
@@ -141,7 +136,7 @@ the electronic state of the sample/target as a function of time during the inter
   \item[Input data:] Wavefront or rays at sample/target interaction point.
   \item[Output data:] Snapshots of electronic state trajectory during the radiation exposure, e.g. electron density, form factors, electronic
     wavefunction or density matrix.
-  \item[Example method:] Molecular Dynamics, Particle-in-cell, Time-Dependent Density Functional Theory, Many-body Perurbation
+  \item[Example method:] Molecular Dynamics, Particle-in-cell, Time-Dependent Density Functional Theory, Many-body Perturbation
     Theory
 \end{description}
 %
@@ -233,7 +228,7 @@ instrument:
 %
 \subsection{Propagation\label{sec:short_pulse_prop}}
 Propagation of XFEL pulses is modeled through the existing XFELPhotonPropagator calculator. The latter is an interface
-to \texttt{WPG} \cite{Samoylova2016_submitted, wpg_github}, a python high level interface for the \texttt{Synchrotron Radiation Workshop} (SRW) \cite{Chubar2008, srw_github}.
+to \texttt{WPG} \cite{Samoylova2016, wpg_github}, a python high level interface for the \texttt{Synchrotron Radiation Workshop} (SRW) \cite{Chubar2008, srw_github}.
 The simulation parameters reflect the conditions at the High Energy Density (HED) instrument \cite{Nakatsutsumi2014}
 at the European XFEL. The focal spotsize can be fixed at three different ranges,
 $\approx 200 \mu\text{m}$, $\approx 20 \mu\text{m}$, and $\approx 2 \mu\text{m}$.
@@ -284,7 +279,7 @@ The detector is currently modeled in two steps: In cases where the scattered rad
 distribution, first a distribution of photons is calculated. To this end,
 the scattered intensity is evaluated on a two dimensional grid corresponding to the pixels of the x-ray
 detector located at a given distance and angle with respect to the target position.
-In each pixel (coordinates $i,j$) the intensity is converted into an average photon number $n_{ij}$ by dividing the intensity
+In each pixel (coordinates $i,j$) the intensity is converted into an average photon number $\bar n_{ij}$ by dividing the intensity
 $I_{ij}$ by the central photon energy $\hbar\omega_{0}$ of the x-ray laser and multiplying by the pulse duration $\tau$,
 \begin{equation}
   \bar n_{ij} = \frac{I_{ij}}{\hbar\omega_0} \tau~.
@@ -298,8 +293,8 @@ from the Poisson distribution $p(m_{ij}) = \frac{\lambda^{m_{ij}}}{m_{ij}\!}\mat
 of the Poisson distribution is fixed at the previously calculated average photon number $\bar n_{ij}$.
 
 Effects which go beyond this simple detector model will be taken into account at a later stage using the
-X-ray Camera Simulation Toolkit \cite{Joy2015}. It has been modified recently to describe x-ray
-detectors that will be employed at the European XFEL as described e.g. in \cite{Rueter2016}. It describes the physical processes
+X-ray Camera Simulation Toolkit (X-CSIT) \cite{Joy2015}. It has been modified recently to describe x-ray
+detectors that will be employed at the European XFEL as described e.g. in \cite{Rueter2016}. X-CSIT describes the physical processes
 of charge creation, charge transport, and electronics on a detailled level including the photo electric effect, Compton
 and Rayleigh scattering, fluorescence and Auger emissions, charge cloud drift and diffusion, plasma formation and screening at
 high charge cloud densities, and simulations of the detector electronics for amplification and digitisation and the corresponding
@@ -340,7 +335,6 @@ TBD
 TBD
 \subsection{Data analysis}
 
-\printglossary
 \printbibliography
 \end{document}
 

--- a/D4.1_2/WP4_D4.1_2.tex
+++ b/D4.1_2/WP4_D4.1_2.tex
@@ -208,13 +208,14 @@ $\approx 200 \mu\text{m}$, $\approx 20 \mu\text{m}$, and $\approx 2 \mu\text{m}$
 \subsection{Photon-Matter interaction}
 The short-pulse laser-plasma interaction is modeled with \texttt{PIConGPU} \cite{Bussmann2013}.
 
-\texttt{PIConGPU} is an Open Source~\cite{picongpu_github} explicit, relativistic 3D3V particle-in-cell (\texttt{PIC}) code which can simulate the interaction of high power, ultra-short laser pulses with matter. 
+\texttt{PIConGPU} is an Open Source~\cite{picongpu_github} explicit, relativistic 3D3V particle-in-cell (\texttt{PIC}) code which can simulate the interaction of high power, ultra-short laser pulses with matter.
 
 High power laser pulses, \texttt{HPL}, are defined by their time dependent magnetic and electric field components and solved on a regular mesh (usually Cartesian) via a so called Maxwell solver using e.g. finite difference time domain techniques~\cite{Yee1966}.
 
 Different to the \texttt{HPL}, the X-ray interaction is modeled via a Monte-Carlo photon interaction model. Each photon is described by its wave vector and a phase\footnote{In the future, the photon model will also include polarization.}.
 
-An X-ray pulse described by temporally and spatially varying intensities and wavefronts will have to be converted into a time-depended spatial distribution of photons. These photons are then tracked through the volume simulated by \texttt{PIConGPU}.
+An X-ray pulse described by temporally and spatially varying intensities and wavefronts will have to be converted into a
+time-dependent spatial distribution of photons. These photons are then tracked through the volume simulated by \texttt{PIConGPU}.
 
 Photons are scattered according to predefined scattering functions that depend on the local properties of the matter irradiated by the HPL. In the most simple case, the local free electron density is used as an input for calculating the probability for Thomson scattering of the photons off free electrons.
 
@@ -237,24 +238,43 @@ Ex-situ scattering is performed by the \texttt{XRT}~\cite{xrt_github} code. The 
 
 In-situ scattering using Lienard-Wiechert potentials will be based on an already existing in-situ Lienard-Wiechert potential calculator plugin to \texttt{PIConGPU} \cite{Pausch2013}. This method will serve mainly as a cross check to the other methods. It involves a modification of the PIC algorithm that will be implemented in the future. The method allows to compute arbitrary angular far field scattering spectra during the interaction of the HPL with matter.
 
-An implementation of in-situ Monte-Carlo photon scattering in \texttt{PIConGPU} would be based on the techniques developed for the \texttt{XRT} code. Here, the main issue is the large memory consumption by the photons traced while the simulation is running. 
+An implementation of in-situ Monte-Carlo photon scattering in \texttt{PIConGPU} would be based on the techniques developed for the \texttt{XRT} code. Here, the main issue is the large memory consumption by the photons traced while the simulation is running.
 
 If in-situ photon scattering can be succesfully implemented, interaction of the X-ray photons with the ions and electrons in the simulation can be implemented. Possible scenarios include elastic scattering of photons from electrons, excitation of ions, absorption and emission of photons. Finally, other processes that produce X-ray photons could be included, such as deexcitation, Bremsstrahlung, etc. These could help to determine backgrounds. In summary, such a framework of physical models would allow for fully kinetic in-situ radiation transport modeling in a particle-in-cell code.
 
 As discussed, development of these capabilities are ongoing and will be subsequently made available in \texttt{simex\_platform} and \texttt{PIConGPU}. Compatibility of all software packages will be ensured by reuse of existing libraries and the common meta data format \texttt{openPMD}.
 
 \subsection{Detection}
-At an early stage, the detector will be modeled as an ideal x-ray detector, i.e. registering the exact number of incident photons in each
-pixel as simulated by the scattering module. At a later stage, the realistic detector response will be modeled within the
-X-ray Camera Simulation Toolkit \cite{Joy2015}.% as described in \cite{Rueter2016_submitted}.
+The scattered intensity is calculated on a two dimensional grid corresponding to the pixels of the x-ray
+detector located at a given distance and angle with respect to the target position.
+In each pixel (coordinates $i,j$) the intensity is converted into an average photon number $n_{ij}$ by dividing the intensity
+$I_{ij}$ by the central photon energy $\hbar\omega_{0}$ of the x-ray laser and multiplying by the pulse duration $\tau$,
+\begin{equation}
+  \bar n_{ij} = \frac{I_{ij}}{\hbar\omega_0} \tau~.
+  \label{eqn:number_of_photons_from_intensity}
+\end{equation}
+The inherent counting statistics of the detector are modeled by
+calculating a "poissonized" photon number. We draw a random number $m_{ij}$
+from the Poisson distribution $p(m_{ij}) = \frac{\lambda^m_{ij}}{m_{ij}\!}\mathrm{e}^{-\lambda}$. The average value $\lambda$
+of the Poisson distribution fixed to previously calculated average photon number $\bar n_{ij}$.
+
+Effects which go beyond this simple detector model will be taken into account at a later stage using the
+X-ray Camera Simulation Toolkit \cite{Joy2015}. It has been modified recently to describe x-ray
+detectors that will be employed at the European XFEL as described e.g. in \cite{Rueter2016}. It describes the physical processes
+of charge creation, charge transport, and electronics on a detailled level including the photo electric effect, Compton
+and Rayleigh scattering, fluorescence and Auger emissions, charge cloud drift and diffusion, plasma formation and screening at
+high charge cloud densities, and simulations of the detector electronics for amplification and digitisation and the corresponding
+noise.
 %
 \subsection{Data analysis}
 From the small-angle x-ray scattering data one can infer important information about the structure of the highly excited target during
 the interaction with the optical laser. E.g. the electron density is directly encoded in the diffraction pattern. In order to
 reconstruct the electron density from the diffraction data, the complex phase of the probe has to be reconstructed using an iterative phasing
 algorithm. Such algorithms are widely available, e.g. \ldots \marginpar{Fill in}.
-The so calculated electron density can then be compared to the particle data in the PIC simulation to assess the reliability of
-the phasing algorithm under given realistic experimental condition. \marginpar{What else would be of interest here?}
+Results of the simulation can then be used to optimize the experimental parameters such as photon energy, pulse length,
+coherence properties, and scattering geometry (detector distance and scattering angle) by e.g. maximizing the signal contrast,
+and signatures of plasma instabilities. Another opportunity is to study the importance of various plasma and radiation effects
+such as inelastic scattering, recombination, and bremsstrahlung.
 
 \section{D4.2: Long pulse laser-matter interaction\label{sec:long_pulse}}
 \subsection{Introduction}

--- a/D4.1_2/WP4_D4.1_2.tex
+++ b/D4.1_2/WP4_D4.1_2.tex
@@ -8,7 +8,12 @@
 %   BIBLIOGRAPHY SETTINGS                     %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \usepackage[bibstyle=nature,sorting=none,=maxnames=1000,eprint=false, defernumbers=true, backend=biber]{biblatex}
+%\usepackage{nomencl}
 \usepackage{hyperref}
+
+\usepackage[nonumberlist]{glossaries}
+
+
 
 \renewcommand*\finalnamedelim{, and\addspace}
 \DeclareNameAlias{sortname}{last-first}
@@ -40,9 +45,12 @@
 \author{Carsten Fortmann-Grote, Axel Huebl, Michael Bussmann } % Add yourself.
 \date{\today}
 
+\makeglossaries
+\newacronym[longplural={Free Electron Lasers}]{fel}{FEL}{Free Electron Laser}
+
 \begin{document}
 \maketitle
-\section{Introduction}
+\abstract{%
 This document describes the design and implementation of simulation software for interaction of intense, coherent radiation from x-ray free
 electron lasers, synchrotrons, and optical lasers with solid, liquid, or gasous samples and targets.
 It discusses the generic simulation platform within which the simulations will be performed and the
@@ -50,36 +58,54 @@ concrete simulation tools for two virtual experiments:
 \begin{enumerate}
   \item Interaction of high power, \textbf{short} pulse optical laser radiation (duration $\approx 10\,\text{fs}$)
     with matter and subsequent probing of the resulting state by intense x-ray pulses,
-  \item Interaction of high energy, \textbf{long} pulses of optical laser light (duration $\approx 10\,\text{ps}$
+  \item Interaction of high energy, \textbf{long} pulses of optical laser light (duration $\approx 10\,\text{ps}$)
     with a solid target and probing with x-rays.
 \end{enumerate}%
+}
 
 \section{The SIMEX simulation platform \label{sec:simex_platform}}
 %
 \subsection{Introduction}
 The computer program \texttt{simex\_platform}
 \cite{simex_github}
-is a platform for the simulation of experiments at advanced laser light sources. It allows the
-user to assemble a virtual experiment through combination of suitable programs for the light source (e.g. a synchrotron, an x-ray free electron
-laser or an optical laser), beam transport from the source to the sample or target, interaction of the light with the sample or target,
-propagation of the scattered light behind the sample or target, and detection in a light detector. \texttt{simex\_platform} comes preloaded with
-a number of such \textit{Calculators}, aimed at the simulation of various typical laser light experiments. Furthermore, researchers
-can replace individual built-in \textit{Calculators} by their own codes. In this way, they can embed their codes
+is a platform for simulation of experiments at advanced laser light sources. The user can
+assemble a virtual experiment through combination of suitable programs for the light source (e.g. synchrotron, \gls{fel}, or conventional laser),
+beam transport from source to sample or target, interaction of the light with the sample or target,
+propagation of the scattered light behind the interaction, and finally detection in a light detector.
+\texttt{simex\_platform} comes preloaded with
+a number of \textit{Calculators}, representing one segment in the experimental setup.
+Generalized and well described calculator interfaces make it easy to switch between different
+\textit{Calculators} thereby describing various classes of experiments or a given experiment with various methods or method
+implementations.
+One ambition of the code project is to enable users to replace the built-in \textit{Calculators} by their own codes.
+In this way, they can embed their codes
 into a more realistic simulation environment compared to running the code in stand-alone fashion with more or less idealized parameters.
 %
 \subsection{Building blocks of a virtual photon experiment}
-With slight variations, photon based experiments can be broken down into six individual blocks: The photon source, the photon transport
+Within this document, the term ``photon based experiment'' refers to an experiment in which electromagnetic radiation travels
+from a given radiation source to a piece of matter (the ``sample'' or ``target''), interacting with it through various
+processes, and, in general, modifying it's macroscopic and microscopic state. Diagnostic devices are used to capture traces of
+the photon-matter interaction, by e.g. measuring the scattered, or transmitted/absorbed radiation,
+charged particles escaping from the interaction, flourescence radiation etc.
+Such a type of experiment can be broken down into six individual blocks: The photon source, the photon transport
 from the source to the experiment, the interaction of photons and matter, propagation of scattered and transmitted radiation from the
-target/sample to the detector and photon detection in a detector, followed by data analysis.
+target/sample to the detector and detection in a detector, followed by data analysis. Later in this report, we will discuss two
+concrete examples for photon-based experiments. Both of them are so-called pump-probe experiments, i.e. they involve two photon
+sources, typically one optical source and one x-ray source. However, only the x-ray source will actually be simulated while the
+optical laser will be parametrized. More complex experiments, FELs based on compact
+laser-plasma electron accelerators are currently beyond the scope of the toolchain described above. But with slight
+modifications to the framework, they can also be included in a somewhat more
+flexible scheme which allows reordering of the \textit{Calculators}.
+
 In \texttt{simex\_platform} each of these blocks is
 represented by an \textit{Abstract Calculator}, which defines virtual methods for communication between subsequent calculators and execution of
 the underlying implementation of a particular algorithm.
 These virtual methods can be used e.g. in a workflow manager to execute the virtual experiment.
-Specialized \textit{Calculators}, derived from the\textit{Abstract Calculator}, implement one particular stage of the simulation, using a
+Specialized \textit{Calculators}, derived from the \textit{Abstract Calculator}, implement one particular stage of the simulation, using a
 specific method or algorithm. Data
 format conversion, execution statements, and submission of calculation tasks to the operating system, are handled on this
 level. The
-\textit{Calculators} are the algorithmic building blocks describing subsequent stages in the beamline.
+\textit{Calculators} are the algorithmic building blocks describing subsequent stages in the photon beamline.
 %
 \subsubsection{Photon source}
 The mechanism to generate the radiation before any optical elements and before any photon-matter interaction has happened.
@@ -88,7 +114,8 @@ The mechanism to generate the radiation before any optical elements and before a
   \item[Physics:] Depending on nature of the source: radiation from charged particle acceleration, spontanuous emission, laser medium.
   \item[Input data:] Parameters of the photon source, e.g. for an undulator: electron bunch charge, electron energy, undulator period and length.
   \item[Output data:] Representation of the light source (e.g. as a wavefront, rays, photon distribution)
-  \item[Example method:] The code FAST \cite{Saldin1999} generates 3D (x-y-t) wavefronts at the exit of the undulator in an x-ray free electron laser.
+  \item[Example method:] The code FAST \cite{Saldin1999} generates 3D (x-y-t) wavefronts at the exit of the undulator in an
+    x-ray free electron laser. Alternative code: Genesis \cite{genesis_code_www}.
 \end{description}
 %
 \subsubsection{Photon Propagation}
@@ -98,21 +125,24 @@ Propagates the radiation as described by the photon source calculator from the s
 \begin{description}
   \item[Abstract calculator:] AbstractPhotonPropagator
   \item[Physics:] Propagation of light through optical elements.
-  \item[Input data:] Wavefront or rays at beginning of beamline.
+  \item[Input data:] Representation of the radiation field at beginning of beamline.
   \item[Output data:] Wavefront or rays at target/sample interaction point.
   \item[Example method:] Fourier optics wavefront propagation, ray tracing.
 \end{description}
 %
 \subsubsection{Photon Interactor}
-Interaction of the photons with the target or sample. Takes into account elementary processes like absorption, emission, scattering of radiation and secondary processes like collisional ionization and recombination. The end product is the electronic state of the sample/target as a function of time during the interaction with the external light source.
+Interaction of the photons with the target or sample. Takes into account elementary processes like absorption, emission,
+scattering of radiation and secondary processes like collisional ionization and recombination. Calculates
+the electronic state of the sample/target as a function of time during the interaction with the external light source.
 \begin{description}
   \item[Abstract calculator:] AbstractPhotonInteractor
   \item[Physics:] Absorption, emission, and scattering of radiation by charged particles. Secondary processes like electron impact ionization, three
     body recombination. Acceleration of particles in external fields and backreaction of excited matter on the radiation.
   \item[Input data:] Wavefront or rays at sample/target interaction point.
-  \item[Output data:] Snapshots of electronic state trajectory during the radiation exposure. E.g. electron density, form factors, electronic
+  \item[Output data:] Snapshots of electronic state trajectory during the radiation exposure, e.g. electron density, form factors, electronic
     wavefunction or density matrix.
-  \item[Example method:] Molecular Dynamics, Particle-in-cell, Ab-initio.
+  \item[Example method:] Molecular Dynamics, Particle-in-cell, Time-Dependent Density Functional Theory, Many-body Perurbation
+    Theory
 \end{description}
 %
 \subsubsection{Photon Diffractor}
@@ -155,9 +185,11 @@ in a single particle diffractive imaging experiment.
 \section{D4.1: Short pulse laser-matter interaction\label{sec:short_pulse}}
 %
 \subsection{Introduction}
-High power short pulse lasers typically deliver laser pulses in the infrared (800~nm to 1000~nm) at pulse durations below one picosecond. Todays high power lasers~\cite{Siebold2008} can reach intensities of up to $10^{21}~\text{W}/\text{cm}^2$ on spot sizes of a few microns and pulse durations on the order of a few ten femtoseconds.
+High power short pulse lasers typically deliver laser pulses in the infrared (800~nm to 1000~nm) at pulse durations below one
+picosecond. Todays high power lasers~\cite{Siebold2008} can reach intensities of up to $10^{21}~\text{W}/\text{cm}^2$ on spot
+sizes of a few microns and pulse durations on the order of a few ten femtoseconds.
 
-Despite their intensity, these sources usually do not penetrate a solid density target but rather create a plasma at the target front side, accelerating electrons to relativistic energies in the strong electric field of the laser~\cite{Kluge2011} and pushing them into the target via the $\vec{v}\times\vec{B}$ force once the velocity $v$ approaches the speed of light~\cite{Mulser2010,Gibbon1996}.
+Despite their intensity, these sources usually do not penetrate a solid density target, but rather create a plasma at the target front side, accelerating electrons to relativistic energies in the strong electric field of the laser~\cite{Kluge2011} and pushing them into the target via the $\vec{v}\times\vec{B}$ force once the velocity $v$ approaches the speed of light~\cite{Mulser2010,Gibbon1996}.
 
 The generation of relativistic electrons at the front side, the transport of electrons through the target and the subsequent formation of a sheeth of electrons at the target rear side all happen on time scales below a few hundred femtoseconds~\cite{Macchi2013}. They can create plasma instabilities~\cite{Metzkes2014}, ionize and heat the target bulk~\cite{Huang2013}, generate strong magnetic fields or drive shocks inside the target.
 
@@ -172,10 +204,11 @@ As a first test of the capabilities of the \texttt{simex\_platform} free electro
 \subsection{X-ray source}
 The x-ray source in this virtual experiment is the SASE2 beamline at the European XFEL, Hamburg, Germany \cite{Tschentscher2011}.
 X-ray pulses are simulated using the code FAST \cite{Saldin1999} developed at DESY. Starting from parameters of the electron linear accelerator
-(e.g. electron energy and bunch charge), FAST simulates the self amplification of stimulated emission (SASE) process \cite{} in the FEL's
-undulator. As a result, the simulation returns the wavefront (i.e. the complex electric field components
+(e.g. electron energy and bunch charge), FAST simulates the self amplification of stimulated emission (SASE) process
+\cite{Kim1986} in the
+FEL. As a result, the simulation returns the wavefront (i.e. the complex electric field components
 along the horizontal and vertical polarization axis) in the plane of the undulator exit. In the coordinate frame of the
-XFEL, this plane has the longitudinal coordinate $z=0$. For practical reasons and because FAST is not a public domain software,
+FEL, this plane has the longitudinal coordinate $z=0$. For practical reasons and because FAST is not a public domain software,
 the FAST wavefront data are read from the x-ray pulse database \cite{xpd_xfel}.
 
 The following x-ray pulse parameters are available:
@@ -183,7 +216,7 @@ The following x-ray pulse parameters are available:
   \item[Photon energy:] 6 - 12 keV. The targeted initial photon energy at the European XFEL is 6 keV.
   \item[energy spread:] SASE operation: 10$^{-3}$, seeded operation: $10^{-5\dots-4}$.
   \item[Pulse duration:] of the order 10 fs.
-  \item[Number of photons] of the order 10$^{12}$.
+  \item[Number of photons per pulse] of the order 10$^{12}$.
 \end{description}
 %
 \subsection{Optical laser source}
@@ -203,7 +236,9 @@ Propagation of XFEL pulses is modeled through the existing XFELPhotonPropagator 
 to \texttt{WPG} \cite{Samoylova2016_submitted, wpg_github}, a python high level interface for the \texttt{Synchrotron Radiation Workshop} (SRW) \cite{Chubar2008, srw_github}.
 The simulation parameters reflect the conditions at the High Energy Density (HED) instrument \cite{Nakatsutsumi2014}
 at the European XFEL. The focal spotsize can be fixed at three different ranges,
-$\approx 200 \mu\text{m}$, $\approx 20 \mu\text{m}$, and $\approx 2 \mu\text{m}$ \marginpar{Fix numbers, how large are the ranges?}
+$\approx 200 \mu\text{m}$, $\approx 20 \mu\text{m}$, and $\approx 2 \mu\text{m}$.
+
+
 %
 \subsection{Photon-Matter interaction}
 The short-pulse laser-plasma interaction is modeled with \texttt{PIConGPU} \cite{Bussmann2013}.
@@ -245,7 +280,9 @@ If in-situ photon scattering can be succesfully implemented, interaction of the 
 As discussed, development of these capabilities are ongoing and will be subsequently made available in \texttt{simex\_platform} and \texttt{PIConGPU}. Compatibility of all software packages will be ensured by reuse of existing libraries and the common meta data format \texttt{openPMD}.
 
 \subsection{Detection}
-The scattered intensity is calculated on a two dimensional grid corresponding to the pixels of the x-ray
+The detector is currently modeled in two steps: In cases where the scattered radiation is represented by an intensity
+distribution, first a distribution of photons is calculated. To this end,
+the scattered intensity is evaluated on a two dimensional grid corresponding to the pixels of the x-ray
 detector located at a given distance and angle with respect to the target position.
 In each pixel (coordinates $i,j$) the intensity is converted into an average photon number $n_{ij}$ by dividing the intensity
 $I_{ij}$ by the central photon energy $\hbar\omega_{0}$ of the x-ray laser and multiplying by the pulse duration $\tau$,
@@ -253,10 +290,12 @@ $I_{ij}$ by the central photon energy $\hbar\omega_{0}$ of the x-ray laser and m
   \bar n_{ij} = \frac{I_{ij}}{\hbar\omega_0} \tau~.
   \label{eqn:number_of_photons_from_intensity}
 \end{equation}
-The inherent counting statistics of the detector are modeled by
+
+Subsequently, or in cases where the scattering calculation yields the photon signal directly,
+the inherent counting statistics of the detector are modeled by
 calculating a "poissonized" photon number. We draw a random number $m_{ij}$
-from the Poisson distribution $p(m_{ij}) = \frac{\lambda^m_{ij}}{m_{ij}\!}\mathrm{e}^{-\lambda}$. The average value $\lambda$
-of the Poisson distribution fixed to previously calculated average photon number $\bar n_{ij}$.
+from the Poisson distribution $p(m_{ij}) = \frac{\lambda^{m_{ij}}}{m_{ij}\!}\mathrm{e}^{-\lambda}$. The average value $\lambda$
+of the Poisson distribution is fixed at the previously calculated average photon number $\bar n_{ij}$.
 
 Effects which go beyond this simple detector model will be taken into account at a later stage using the
 X-ray Camera Simulation Toolkit \cite{Joy2015}. It has been modified recently to describe x-ray
@@ -301,6 +340,7 @@ TBD
 TBD
 \subsection{Data analysis}
 
+\printglossary
 \printbibliography
 \end{document}
 

--- a/D4.1_2/references.bib
+++ b/D4.1_2/references.bib
@@ -342,7 +342,6 @@ url="http://dx.doi.org/10.1007/s00340-007-2907-0"
   url   = {https://github.com/ochubar/SRW},
 }
 
-@Comment{jabref-meta: databaseType:biblatex;}
 
 @InProceedings{Rueter2016,
   author    = {Rueter, Tonn},
@@ -352,3 +351,12 @@ url="http://dx.doi.org/10.1007/s00340-007-2907-0"
   file      = {:Rueter2016.pdf:PDF},
   timestamp = {2016.06.27},
 }
+
+@WWW{genesis_code_www,
+  title     = {The GENESIS code homepage},
+  url       = {http://genesis.web.psi.ch/index.html},
+  owner     = {grotec},
+  timestamp = {2016.07.25},
+}
+
+@Comment{jabref-meta: databaseType:biblatex;}

--- a/D4.1_2/references.bib
+++ b/D4.1_2/references.bib
@@ -95,7 +95,7 @@ month={May},}
 	abstract         = "We demonstrate the potential of X-ray free-electron lasers (XFEL) to advance the understanding of complex plasma dynamics by allowing for the first time nanometer and femtosecond resolution at the same time in plasma diagnostics. Plasma phenomena on such short timescales are of high relevance for many fields of physics, in particular in the ultra-intense ultra-short laser interaction with matter. Highly relevant yet only partially understood phenomena become directly accessible in experiment. These include relativistic laser absorption at solid targets, creation of energetic electrons and electron transport in warm dense matter, including the seeding and development of surface and beam instabilities, ambipolar expansion, shock formation, and dynamics at the surfaces or at buried layers. In this paper, we focus on XFEL plasma probing for high power laser matter interactions based on quantitative calculations using synthesized data and evaluate the feasibility of various imaging and scattering techniques with special focus on the small angle X-ray scattering technique.",
 	keywords         = "xfel, plasma, high power. laser, femtosecond, scattering, sax",
 	howpublished     = "http://scitation.aip.org/content/aip/journal/pop/21/3/10.1063/1.4869331"}
- 	
+
 @article {Huang2013,
 	title            = "Ion heating dynamics in solid buried layer targets irradiated by ultra-short intense laser pulses",
 	year             = "2013",
@@ -343,3 +343,12 @@ url="http://dx.doi.org/10.1007/s00340-007-2907-0"
 }
 
 @Comment{jabref-meta: databaseType:biblatex;}
+
+@InProceedings{Rueter2016,
+  author    = {Rueter, Tonn},
+  title     = {X-RAY DETECTOR SIMULATION PIPELINES FOR THE EUROPEAN XFEL},
+  booktitle = {IEEE Conference Proceedings of the Nuclear Science Symposium 2015},
+  year      = {2016},
+  file      = {:Rueter2016.pdf:PDF},
+  timestamp = {2016.06.27},
+}

--- a/D4.1_2/references.bib
+++ b/D4.1_2/references.bib
@@ -236,12 +236,6 @@ url="http://dx.doi.org/10.1007/s00340-007-2907-0"
   url   = {https://github.com/eucall-software/simex_platform},
 }
 
-@Article{Samoylova2016_submitted,
-  author  = {Samoylova, Liubov},
-  title   = {No Title},
-  journal = {J. Appl. Crystallogr.},
-}
-
 @WWW{wpg_github,
   title = {https://github.com/samoylv/WPG},
   url   = {https://github.com/samoylv/WPG},
@@ -357,6 +351,33 @@ url="http://dx.doi.org/10.1007/s00340-007-2907-0"
   url       = {http://genesis.web.psi.ch/index.html},
   owner     = {grotec},
   timestamp = {2016.07.25},
+}
+
+@Article{Kim1986,
+  author       = {K.-J. Kim},
+  title        = {Three-dimensional analysis of coherent amplification and self-amplified spontaneous emission in free-electron lasers},
+  journaltitle = {Phys. Rev. Letters},
+  year         = {1986},
+  volume       = {57},
+  pages        = {1871},
+  owner        = {grotec},
+  timestamp    = {2016.07.26},
+}
+
+@Article{Samoylova2016,
+  author    = {Liubov Samoylova and Alexey Buzmakov and Oleg Chubar and Harald Sinn},
+  title     = {{WavePropaGator}: interactive framework for X-ray free-electron laser optics design and simulations},
+  year      = {2016},
+  volume    = {49},
+  number    = {4},
+  month     = {jul},
+  doi       = {10.1107/s160057671600995x},
+  url       = {http://dx.doi.org/10.1107/S160057671600995X},
+  file      = {:Samoylova2016.pdf:PDF},
+  journal   = {J. Appl. Crystallogr.},
+  owner     = {grotec},
+  publisher = {International Union of Crystallography ({IUCr})},
+  timestamp = {2016.07.18},
 }
 
 @Comment{jabref-meta: databaseType:biblatex;}


### PR DESCRIPTION
Hi,
can someone from HZDR please review the changes and address the following:
* possible nameclash: XRT is a well known code for X-Ray Tracing, which we are currently incorporating in 
simex_platform (branch #xrt_calculator). If I understand correctly there will be a code with the same name for x-ray scattering, soon. Can we avoid having two codes with the same acronym? Or is the hzdr xrt project a fork of the raytracer ?
* Line 307 is still missing some information. I added this (half)sentence assuming that phasing diffraction data is part of the typical workflow for forward scattering experiments. If this is inaccurate, please remove the line, otherwise a reference to the phasing algorithm would be nice.

Thanks a lot!